### PR TITLE
Uses the country code to fetch the correct currency

### DIFF
--- a/theme-demo-bar.php
+++ b/theme-demo-bar.php
@@ -61,14 +61,16 @@ class Theme_Demo_Sites_Display {
 			return $this->premium_theme_data;
 		}
 
-		$transient_key     = "atomic-premium-theme-data:$stylesheet";
+		$country_code = $_SERVER['GEOIP_COUNTRY_CODE'] ?? 'US';
+
+		$transient_key     = "atomic-premium-theme-data:$country_code:$stylesheet";
 		$cached_theme_data = get_transient( $transient_key );
 		if ( is_object( $cached_theme_data ) ) {
 			return $cached_theme_data;
 		}
 
 		$response = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
-			"themes/{$stylesheet}/premium-details",
+			"themes/{$stylesheet}/premium-details?country_code={$country_code}",
 			'2',
 			array(
 				'method' => 'GET',


### PR DESCRIPTION
Add the country code on the `premium-details` endpoint. The endpoint will receive this information to apply the correct currency to the pricing.
The country code is received from the $_SERVER['GEOIP_COUNTRY_CODE'].

The key for the caching was also updated to cache the request response based on the user's country.

### Testing Instructions
1. Apply the patch https://code.a8c.com/D89981 to your sandbox.
2. Sandbox your WoA site(https://fieldguide.automattic.com/jetpack-education-curriculum/development-environment/#making-your-browser-believe-that-wordpress-com-and-jetpack-com-live-in-your-sandbox)
3. Clone this repo and change it to the branch `add/country-code`
4. Zip the repo folder
5. On your WoA site, upload the Zip file via WordPress Admin: https://wordpress.org/support/article/managing-plugins/#upload-via-wordpress-admin
6. On your WoA VM, open the plugin file:`nano htdocs/wp-content/plugins/theme-demo-bar-plugin/theme-demo-bar.php`
7. Scroll down to the function `wpcomsh_is_theme_demo_site` and make it return true. This will make your site be considered a demo site.
8. Navigate to your WoA Site. You should see the demo bar with the appropriate currency.
