### PR TITLE
Removing wpcomsh prefix from the plugin functions

### DIFF
--- a/theme-demo-bar.php
+++ b/theme-demo-bar.php
@@ -360,20 +360,20 @@ class Theme_Demo_Sites_Display {
  *
  * @return bool
  */
-function wpcomsh_is_theme_demo_site() {
+function is_theme_demo_site() {
 	return wpcomsh_is_site_sticker_active( 'theme-demo-site' );
 }
 
 /**
  * Instantiate only for known theme demo sites and block patterns source sites
  *
- * @uses wpcomsh_is_theme_demo_site
+ * @uses is_theme_demo_site
  * @uses Theme_Demo_Sites_Display::instance
  * @return void
  */
-function wpcomsh_theme_demo_sites_display() {
-	if ( wpcomsh_is_theme_demo_site() ) {
+function theme_demo_sites_display() {
+	if ( is_theme_demo_site() ) {
 		Theme_Demo_Sites_Display::instance();
 	}
 }
-add_action( 'init', 'wpcomsh_theme_demo_sites_display' );
+add_action( 'init', 'theme_demo_sites_display' );


### PR DESCRIPTION
Removes the `wpcomsh` prefix from the functions defined in this plugin.

### Testing instruction
* Clone this repo and change it to the branch  `remove-wpcomsh-prefix`
* Zip the repo folder
* On your WoA site, upload the Zip file via WordPress Admin: https://wordpress.org/support/article/managing-plugins/#upload-via-wordpress-admin
* On your WoA VM, open the plugin file: `nano htdocs/wp-content/plugins/theme-demo-bar-plugin/theme-demo-bar.php`
* Scroll down to the function `is_theme_demo_site` and make it return true. This will make your site be considered a demo site.
* Navigate to your WoA Site. You should see the demo bar.