### PR TITLE
Adding spacing if the admin bar is displaying

### DIFF
--- a/theme-demo-bar.css
+++ b/theme-demo-bar.css
@@ -54,7 +54,8 @@
 	width: 100%;
 	z-index: 999999;
 }
-body.logged-in .demosite-activate {
+body.logged-in .demosite-activate, 
+body.admin-bar .demosite-activate {
 	top: 32px !important;
 }
 /*


### PR DESCRIPTION
If the user were not logged in, the demo bar wouldn't have the proper spacing, leaving the admin bar over it.

Before:
![Screen Shot 2022-10-24 at 09 19 41](https://user-images.githubusercontent.com/1234758/197591067-6ef30663-aac6-4160-9a33-ab82db2d1fce.png)

After:
![Screen Shot 2022-11-02 at 08 28 11](https://user-images.githubusercontent.com/1234758/199478693-e8600544-c71f-4820-bf05-8c57fc3d7d76.png)


### Testing instruction
* Clone this repo and change it to the branch  `update/spacing-for-admin-bar`
* Zip the repo folder
* On your WoA site, upload the Zip file via WordPress Admin: https://wordpress.org/support/article/managing-plugins/#upload-via-wordpress-admin
* On your WoA VM, open the plugin file: `nano htdocs/wp-content/plugins/theme-demo-bar-plugin/theme-demo-bar.php`
* Scroll down to the function `is_theme_demo_site` and make it return true. This will make your site be considered a demo site.
* **Navigate to your WoA Site in incognito mode**. The admin bar shouldn't be over the demo bar.