### PR TITLE
Remove theme price from the demo bar

### DIFF
--- a/theme-demo-bar.php
+++ b/theme-demo-bar.php
@@ -188,16 +188,6 @@ class Theme_Demo_Sites_Display {
 	}
 
 	/**
-	 * Get the premium theme slug
-	 *
-	 * @param string $stylesheet stylesheet slug
-	 * @return string
-	 */
-	private function get_theme_slug( $stylesheet ) {
-		return "premium/{$stylesheet}";
-	}
-
-	/**
 	 * Check if the theme is premium for a given stylesheet
 	 *
 	 * @param string $stylesheet stylesheet slug
@@ -238,11 +228,10 @@ class Theme_Demo_Sites_Display {
 		// 'theme' and 'demo-blog'
 		$url = add_query_arg(
 			array(
-				'theme'   => rawurlencode( $this->get_theme_slug( $theme->stylesheet ) ),
 				'premium' => $this->is_premium_theme( $theme->stylesheet ) ? 'true' : false,
 				'ref'     => 'demo-blog',
 			),
-			'https://wordpress.com/start/with-theme'
+			'https://wordpress.com/theme/' . rawurlencode( $theme->stylesheet )
 		);
 
 		$title    = __( 'Start your WordPress.com site with this theme.' );

--- a/theme-demo-bar.php
+++ b/theme-demo-bar.php
@@ -247,23 +247,11 @@ class Theme_Demo_Sites_Display {
 
 		$title    = __( 'Start your WordPress.com site with this theme.' );
 		$tab_text = __( 'Sign Up Now' );
-		$text     = __( 'Start a site with this theme.' );
-		$button   = __( 'Activate' );
 
 		if ( $this->is_premium_theme( $theme->stylesheet ) ) {
-			$tab_text = __( 'Purchase' );
-			$text     = __( 'Create a site and purchase this theme to start using it now.' );
-			$button   = __( 'Purchase &amp; Activate' );
+			$tab_text = __( 'Start now' );
 		}
 
-		// if the site is premium, set $theme_price
-		$theme_price = '';
-
-		$premium_theme_data = $this->get_premium_theme_data( $theme->stylesheet );
-
-		if ( $premium_theme_data && $this->is_premium_theme( $theme->stylesheet ) && $theme->is_allowed( 'network' ) ) {
-			$theme_price = '<span class="theme-price">' . $premium_theme_data->cost . '</span>';
-		}
 		?>
 
 		<div id="demosite-activate-wrap" class="demosite-activate">
@@ -276,7 +264,6 @@ class Theme_Demo_Sites_Display {
 				<a class="demosite-activate-trigger" href="<?php echo esc_url( $url ); ?>">
 					<?php
 						echo $tab_text; //phpcs:ignore
-						echo $theme_price; //phpcs:ignore
 					?>
 				</a>
 				<a class="demosite-activate-cta-arrow" href="<?php echo esc_url( $url ); ?>">


### PR DESCRIPTION
We don't sell themes as one-off purchases now.

I also changed the URL to match the simple-site theme demo bar - the existing one used here no longer worked.

I made some small other code clean-up changes - removing unused variables.


### Test steps
 1. Download the plugin zip
 2. Modify `theme-demo-bar.php` to hardcode the `is_theme_demo_sites_display` method to return true
 3. Rezip it all up
 4. Upload to an atomic site
 5. Change the site to use a "premium" theme like Tsubaki
 6. Visit the front-end of the site and look at the theme demo bar at the top
 7. Follow the link and see you're taken to the theme showcase

Before | After
-------|------
<img width="1475" alt="Screenshot 2023-12-20 at 22 30 43" src="https://github.com/Automattic/theme-demo-bar-plugin/assets/93301/a30cc83f-fc71-46ad-80b5-bc9a131cbfa5"> | <img width="1475" alt="Screenshot 2023-12-20 at 22 31 10" src="https://github.com/Automattic/theme-demo-bar-plugin/assets/93301/dd7e3bc3-512c-4f1e-9b5b-8025383d5d41">

### Scope

I'd like to get this shipped, so it unblocks some other work.

 * I'm happy to follow-up for wording suggestions but that's likely to change in future, see https://github.com/Automattic/wp-calypso/issues/85539

Fixes: https://github.com/Automattic/dotcom-forge/issues/4856 